### PR TITLE
using tensorflow 2.17

### DIFF
--- a/pps_mw_training/models/mlp_model.py
+++ b/pps_mw_training/models/mlp_model.py
@@ -1,5 +1,5 @@
-from tensorflow.keras import Input, Sequential  # type: ignore
-from tensorflow.keras.layers import Dense  # type: ignore
+from keras import Input, Sequential  # type: ignore
+from keras.layers import Dense  # type: ignore
 
 
 class MlpModel(Sequential):

--- a/pps_mw_training/models/predictors/unet_predictor.py
+++ b/pps_mw_training/models/predictors/unet_predictor.py
@@ -40,7 +40,7 @@ class UnetPredictor:
             config["n_features"],
             config["n_layers"],
         )
-        model.build((None, None, None, n_inputs))
+        model.build_graph(config["image_size"], n_inputs)
         model.load_weights(config["model_weights"])
         return cls(
             model,

--- a/pps_mw_training/models/trainers/mlp_trainer.py
+++ b/pps_mw_training/models/trainers/mlp_trainer.py
@@ -4,7 +4,7 @@ from typing import cast, Any, List, Dict
 import json
 
 import tensorflow as tf  # type: ignore
-from tensorflow.keras.callbacks import ModelCheckpoint  # type: ignore
+from keras.callbacks import ModelCheckpoint  # type: ignore
 from xarray import Dataset  # type: ignore
 
 from pps_mw_training.models.mlp_model import MlpModel
@@ -74,7 +74,7 @@ class MlpTrainer(MlpPredictor):
             ),
         )
         output_path.mkdir(parents=True, exist_ok=True)
-        weights_file = output_path / "weights.h5"
+        weights_file = output_path / "iwp_ici.weights.h5"
         history = model.fit(
             cls.prepare_data(
                 input_parameters,

--- a/pps_mw_training/models/trainers/unet_trainer.py
+++ b/pps_mw_training/models/trainers/unet_trainer.py
@@ -108,6 +108,7 @@ class UnetTrainer(UnetPredictor):
                         "n_unet_blocks": n_unet_blocks,
                         "n_features": n_features,
                         "n_layers": n_layers,
+                        "image_size": image_size,
                         "quantiles": quantiles,
                         "fill_value": fill_value_images,
                         "model_weights": weights_file.as_posix(),

--- a/pps_mw_training/models/trainers/unet_trainer.py
+++ b/pps_mw_training/models/trainers/unet_trainer.py
@@ -61,7 +61,7 @@ class UnetTrainer(UnetPredictor):
                 n_features,
                 n_layers,
             )
-            model.build((None, None, None, n_inputs))
+            model.build_graph(image_size, n_inputs)
         learning_rate = tf.keras.optimizers.schedules.CosineDecay(
             initial_learning_rate=initial_learning_rate,
             decay_steps=int(
@@ -76,7 +76,7 @@ class UnetTrainer(UnetPredictor):
             ),
         )
         output_path.mkdir(parents=True, exist_ok=True)
-        weights_file = output_path / "weights.h5"
+        weights_file = output_path / "pr_nordic.weights.h5"
         training_data = training_data.map(
             lambda x, y: random_crop_and_flip(x, y, tf.constant(image_size))
         )

--- a/pps_mw_training/models/trainers/utils.py
+++ b/pps_mw_training/models/trainers/utils.py
@@ -2,6 +2,7 @@ import gc
 import os
 import psutil
 
+from keras.backend import clear_session  # type: ignore
 from keras.callbacks import Callback  # type: ignore
 
 
@@ -26,4 +27,4 @@ class MemoryUsageCallback(Callback):
     def on_epoch_end(self, epoch, logs=None):
         print(f"On epoch {epoch + 1} end: {self.info()}")
         gc.collect()
-        k.clear_session()
+        clear_session()

--- a/pps_mw_training/models/trainers/utils.py
+++ b/pps_mw_training/models/trainers/utils.py
@@ -2,8 +2,7 @@ import gc
 import os
 import psutil
 
-from tensorflow.keras import backend as k  # type: ignore
-from tensorflow.keras.callbacks import Callback  # type: ignore
+from keras.callbacks import Callback  # type: ignore
 
 
 class MemoryUsageCallback(Callback):
@@ -13,7 +12,7 @@ class MemoryUsageCallback(Callback):
         return f"{psutil.Process(os.getpid()).memory_info().rss / 1e6} MB"
 
     def learning_rate(self):
-        return float(k.get_value(self.model.optimizer.lr))
+        return float(self.model.optimizer.learning_rate)
 
     def info(self):
         return (

--- a/pps_mw_training/pipelines/pr_nordic/training_data.py
+++ b/pps_mw_training/pipelines/pr_nordic/training_data.py
@@ -192,8 +192,8 @@ def get_training_dataset(
     """Get training dataset."""
     assert train_fraction + validation_fraction + test_fraction == 1
 
-    sat_files = list((training_data_path / "satellite").glob('*.nc*'))
-    radar_files = list((training_data_path / "radar").glob('*.nc*'))
+    sat_files = list((training_data_path / "satellite").glob("*.nc*"))
+    radar_files = list((training_data_path / "radar").glob("*.nc*"))
     files = match_files(sat_files, radar_files)
 
     train_size = int(len(files) * train_fraction)

--- a/pps_mw_training/pipelines/pr_nordic/training_data.py
+++ b/pps_mw_training/pipelines/pr_nordic/training_data.py
@@ -205,7 +205,7 @@ def get_training_dataset(
             batch_size,
             qi_min,
             distance_max,
-            params=json.dumps(input_params),
+            input_params=json.dumps(input_params),
             fill_value_mw=fill_value_mw,
             fill_value_radar=fill_value_radar,
         ) for f in [

--- a/pps_mw_training/utils/blocks.py
+++ b/pps_mw_training/utils/blocks.py
@@ -1,6 +1,6 @@
 import tensorflow as tf  # type: ignore
 from tensorflow import keras
-from tensorflow.keras import layers  # type: ignore
+from keras import layers  # type: ignore
 
 from pps_mw_training.utils.layers import SymmetricPadding, UpSampling2D
 

--- a/pps_mw_training/utils/blocks.py
+++ b/pps_mw_training/utils/blocks.py
@@ -15,14 +15,7 @@ class ConvolutionBlock(layers.Layer):
         super().__init__()
         self.block = keras.Sequential()
         self.block.add(SymmetricPadding(1))
-        self.block.add(
-            layers.Conv2D(
-                channels_out,
-                3,
-                padding="valid",
-                input_shape=(None, None, channels_in),
-            )
-        )
+        self.block.add(layers.Conv2D(channels_out, 3, padding="valid"))
         self.block.add(layers.BatchNormalization())
         self.block.add(layers.ReLU())
         self.block.add(SymmetricPadding(1))
@@ -60,7 +53,6 @@ class UpsamplingBlock(layers.Layer):
         self.reduce_channels = layers.Conv2D(
             channels_in // 2, 1,
             padding="same",
-            input_shape=(None, None, channels_in),
         )
         self.concat = layers.Concatenate()
         self.conv_block = ConvolutionBlock(channels_in, channels_out)

--- a/pps_mw_training/utils/layers.py
+++ b/pps_mw_training/utils/layers.py
@@ -1,5 +1,5 @@
 import tensorflow as tf  # type: ignore
-from tensorflow.keras import layers  # type: ignore
+from keras import layers  # type: ignore
 
 
 class SymmetricPadding(layers.Layer):

--- a/pps_mw_training_environment.yml
+++ b/pps_mw_training_environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - python=3.10
+  - python=3.12
   - dask
   - graphviz
   - h5py
@@ -13,5 +13,5 @@ dependencies:
   - psutil
   - pydot
   - pyproj
-  - tensorflow
+  - tensorflow=2.17
   - xarray

--- a/pps_mw_training_environment.yml
+++ b/pps_mw_training_environment.yml
@@ -1,8 +1,6 @@
 name: pps-mw-training
 channels:
   - conda-forge
-  - defaults
-  - nsidc
 
 dependencies:
   - python=3.10

--- a/requirements.in
+++ b/requirements.in
@@ -5,5 +5,5 @@ netcdf4
 numpy
 psutil
 pyproj
-tensorflow
+tensorflow==2.17.0
 xarray

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,191 +4,176 @@
 #
 #    pip-compile requirements.in
 #
-absl-py==1.4.0
+absl-py==2.1.0
     # via
+    #   keras
     #   tensorboard
     #   tensorflow
 astunparse==1.6.3
     # via tensorflow
-cachetools==5.3.1
-    # via google-auth
-certifi==2023.5.7
+certifi==2024.8.30
     # via
     #   netcdf4
     #   pyproj
     #   requests
-cftime==1.6.2
+cftime==1.6.4.post1
     # via netcdf4
-charset-normalizer==3.1.0
+charset-normalizer==3.4.0
     # via requests
 click==8.1.7
     # via dask
-cloudpickle==2.2.1
+cloudpickle==3.1.0
     # via dask
-contourpy==1.1.0
+contourpy==1.3.0
     # via matplotlib
-cycler==0.11.0
+cycler==0.12.1
     # via matplotlib
-dask==2023.9.2
+dask==2024.11.0
     # via -r requirements.in
-flatbuffers==23.5.26
+flatbuffers==24.3.25
     # via tensorflow
-fonttools==4.40.0
+fonttools==4.54.1
     # via matplotlib
-fsspec==2023.9.2
+fsspec==2024.10.0
     # via dask
-gast==0.4.0
+gast==0.6.0
     # via tensorflow
-google-auth==2.20.0
-    # via
-    #   google-auth-oauthlib
-    #   tensorboard
-google-auth-oauthlib==1.0.0
-    # via tensorboard
 google-pasta==0.2.0
     # via tensorflow
-grpcio==1.54.2
+grpcio==1.67.1
     # via
     #   tensorboard
     #   tensorflow
-h5py==3.8.0
+h5py==3.12.1
     # via
     #   -r requirements.in
+    #   keras
     #   tensorflow
-idna==3.4
+idna==3.10
     # via requests
-importlib-metadata==6.8.0
+importlib-metadata==8.5.0
     # via dask
-jax==0.4.12
+keras==3.6.0
     # via tensorflow
-keras==2.12.0
-    # via tensorflow
-kiwisolver==1.4.4
+kiwisolver==1.4.7
     # via matplotlib
-libclang==16.0.0
+libclang==18.1.1
     # via tensorflow
 locket==1.0.0
     # via partd
-markdown==3.4.3
+markdown==3.7
     # via tensorboard
-markupsafe==2.1.3
+markdown-it-py==3.0.0
+    # via rich
+markupsafe==3.0.2
     # via werkzeug
-matplotlib==3.7.1
+matplotlib==3.9.2
     # via -r requirements.in
-ml-dtypes==0.2.0
-    # via jax
-netcdf4==1.6.4
+mdurl==0.1.2
+    # via markdown-it-py
+ml-dtypes==0.4.1
+    # via
+    #   keras
+    #   tensorflow
+namex==0.0.8
+    # via keras
+netcdf4==1.7.2
     # via -r requirements.in
-numpy==1.23.5
+numpy==1.26.4
     # via
     #   -r requirements.in
     #   cftime
     #   contourpy
     #   h5py
-    #   jax
+    #   keras
     #   matplotlib
     #   ml-dtypes
     #   netcdf4
-    #   opt-einsum
     #   pandas
-    #   scipy
     #   tensorboard
     #   tensorflow
     #   xarray
-oauthlib==3.2.2
-    # via requests-oauthlib
-opt-einsum==3.3.0
-    # via
-    #   jax
-    #   tensorflow
-packaging==23.1
+opt-einsum==3.4.0
+    # via tensorflow
+optree==0.13.0
+    # via keras
+packaging==24.2
     # via
     #   dask
+    #   keras
     #   matplotlib
+    #   tensorboard
     #   tensorflow
     #   xarray
-pandas==2.0.2
+pandas==2.2.3
     # via xarray
-partd==1.4.0
+partd==1.4.2
     # via dask
-pillow==9.5.0
+pillow==11.0.0
     # via matplotlib
-protobuf==4.23.3
+protobuf==4.25.5
     # via
     #   tensorboard
     #   tensorflow
-psutil==5.9.5
+psutil==6.1.0
     # via -r requirements.in
-pyasn1==0.5.0
-    # via
-    #   pyasn1-modules
-    #   rsa
-pyasn1-modules==0.3.0
-    # via google-auth
-pyparsing==3.0.9
+pygments==2.18.0
+    # via rich
+pyparsing==3.2.0
     # via matplotlib
-pyproj==3.6.0
+pyproj==3.7.0
     # via -r requirements.in
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-pytz==2023.3
+pytz==2024.2
     # via pandas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via dask
-requests==2.31.0
-    # via
-    #   requests-oauthlib
-    #   tensorboard
-requests-oauthlib==1.3.1
-    # via google-auth-oauthlib
-rsa==4.9
-    # via google-auth
-scipy==1.10.1
-    # via jax
+requests==2.32.3
+    # via tensorflow
+rich==13.9.4
+    # via keras
 six==1.16.0
     # via
     #   astunparse
-    #   google-auth
     #   google-pasta
     #   python-dateutil
+    #   tensorboard
     #   tensorflow
-tensorboard==2.12.3
+tensorboard==2.17.1
     # via tensorflow
-tensorboard-data-server==0.7.1
+tensorboard-data-server==0.7.2
     # via tensorboard
-tensorflow==2.12.0
+tensorflow==2.17.0
     # via -r requirements.in
-tensorflow-estimator==2.12.0
+tensorflow-io-gcs-filesystem==0.37.1
     # via tensorflow
-tensorflow-io-gcs-filesystem==0.32.0
+termcolor==2.5.0
     # via tensorflow
-termcolor==2.3.0
-    # via tensorflow
-toolz==0.12.0
+toolz==1.0.0
     # via
     #   dask
     #   partd
-typing-extensions==4.6.3
-    # via tensorflow
-tzdata==2023.3
+typing-extensions==4.12.2
+    # via
+    #   optree
+    #   rich
+    #   tensorflow
+tzdata==2024.2
     # via pandas
-urllib3==1.26.16
-    # via
-    #   google-auth
-    #   requests
-werkzeug==2.3.6
+urllib3==2.2.3
+    # via requests
+werkzeug==3.1.3
     # via tensorboard
-wheel==0.40.0
-    # via
-    #   astunparse
-    #   tensorboard
-wrapt==1.14.1
+wheel==0.45.0
+    # via astunparse
+wrapt==1.16.0
     # via tensorflow
-xarray==2023.5.0
+xarray==2024.10.0
     # via -r requirements.in
-zipp==3.17.0
+zipp==3.21.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,7 @@ import setuptools
 
 here = Path(__file__).parent.absolute()
 required = [
-    r for r in (here / 'requirements.txt').read_text().splitlines()
-    if '=' in r or "git" in r
+    r for r in (here / 'requirements.in').read_text().splitlines()
 ]
 version = re.findall(
     r'__version__ *= *[\'"]([^\'"]+)',

--- a/tox.ini
+++ b/tox.ini
@@ -2,14 +2,14 @@
 envlist = mypy,lint
 skipsdist = True
 
-[testenv:py310]
+[testenv:py312]
 deps =
     -rrequirements.txt
     pytest
 sitepackages = True
 passenv = *
 setenv =
-    PYTHONPATH = {toxinidir}{:}/usr/lib/python3.10/dist-packages/
+    PYTHONPATH = {toxinidir}{:}/usr/lib/python3.12/dist-packages/
 commands =
     pytest tests {posargs}
 


### PR DESCRIPTION
Bumping tensorflow to 2.17. 

We earlier had an issue that the memory usage was steadily increasing during the training, and this could ultimately lead to an out of memory error. This memory leakage problem seems to have been resolved in more recent tensorflow versions than used previously (2.12).  
